### PR TITLE
Enable cosign keyless signing

### DIFF
--- a/.github/workflows/wc-build.yml
+++ b/.github/workflows/wc-build.yml
@@ -106,6 +106,8 @@ jobs:
       env:
         BUILD_PROFILE: ${{ matrix.profile }}
         BUILD_TARGET: ${{ matrix.target }}
+        COSIGN_EXPERIMENTAL: "1"
+        COSIGN_YES: "true"
     - name: Generate artifact attestation
       if: ${{ !startsWith(github.event_name, 'pull') && matrix.profile == 'release' }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0


### PR DESCRIPTION
## Summary
- enable cosign keyless signing in the release cosign step by exporting COSIGN_EXPERIMENTAL and COSIGN_YES

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fd9615212c83278d19aea6a6ec64da