### PR TITLE
Add cosign flag to disable signing config

### DIFF
--- a/tasks/build.task.yml
+++ b/tasks/build.task.yml
@@ -134,5 +134,6 @@ tasks:
     - >-
       cosign sign-blob {{.ARTIFACT}}
       -y
+      --use-signing-config=false
       --output-certificate {{.ARTIFACT}}.cert
       --output-signature {{.ARTIFACT}}.sig


### PR DESCRIPTION
## Summary
- add the --use-signing-config=false flag to the cosign sign-blob command used by the cosign task

## Testing
- task --summary cosign *(fails: task is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd9ed922608327859c767679d63bed