### PR TITLE
refactor: use match statement for validation clarity in shell provisi…

### DIFF
--- a/src/provisioners/shell.rs
+++ b/src/provisioners/shell.rs
@@ -39,7 +39,9 @@ impl ShellProvisioner {
     fn validate(&self) -> Result<()> {
         match (&self.script, &self.content) {
             (Some(_), None) | (None, Some(_)) => Ok(()),
-            (Some(_), Some(_)) => bail!("shell provisioner cannot specify both 'script' and 'content'"),
+            (Some(_), Some(_)) => {
+                bail!("shell provisioner cannot specify both 'script' and 'content'")
+            }
             (None, None) => bail!("shell provisioner must specify either 'script' or 'content'"),
         }
     }


### PR DESCRIPTION
…oner

Replace boolean equality check with explicit match statement in ShellProvisioner::validate() method. The new approach makes the intent clearer by directly showing the "both Some or both None" conditions rather than relying on boolean equality logic.

Addresses PR review comment: https://github.com/takumin/rsdebstrap/pull/368#discussion_r2702336369