### PR TITLE
Refactor provisioner path resolution and resolve shell script paths relative to profile directory

### DIFF
--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -3,9 +3,9 @@ mod helpers;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use rsdebstrap::backends::mmdebstrap;
-use rsdebstrap::config::load_profile;
+use rsdebstrap::config::{ProvisionerConfig, load_profile};
 use std::io::Write;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, tempdir};
 
 #[test]
 fn test_load_profile_basic() -> Result<()> {
@@ -273,6 +273,48 @@ provisioners:
     let profile = load_profile(path)?;
 
     assert!(profile.validate().is_err());
+
+    Ok(())
+}
+
+#[test]
+fn test_load_profile_resolves_shell_script_relative_to_profile_dir() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let profile_path = temp_dir.path().join("profile.yml");
+    let scripts_dir = temp_dir.path().join("scripts");
+    std::fs::create_dir_all(&scripts_dir)?;
+    let script_path = scripts_dir.join("provision.sh");
+    std::fs::write(&script_path, "#!/bin/sh\necho hello\n")?;
+
+    let mut file = std::fs::File::create(&profile_path)?;
+    // editorconfig-checker-disable
+    writeln!(
+        file,
+        r#"---
+dir: /tmp/test
+bootstrap:
+  type: mmdebstrap
+  suite: bookworm
+  target: rootfs.tar.zst
+provisioners:
+  - type: shell
+    script: scripts/provision.sh
+"#
+    )?;
+    // editorconfig-checker-enable
+
+    let path = Utf8Path::from_path(&profile_path).unwrap();
+    let profile = load_profile(path)?;
+
+    match profile.provisioners.as_slice() {
+        [ProvisionerConfig::Shell(shell)] => {
+            assert_eq!(
+                shell.script.as_ref().unwrap(),
+                &Utf8PathBuf::from_path_buf(script_path).unwrap()
+            );
+        }
+        _ => panic!("expected one shell provisioner"),
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Ensure relative `script` paths in `ShellProvisioner` are interpreted relative to the profile file location so bundled scripts next to profiles work reliably.
- Encapsulate the path-resolution logic to make `load_profile` clearer and avoid irrefutable pattern warnings.

### Description
- Add a helper `resolve_provisioner_paths(profile: &mut Profile, profile_dir: &Utf8Path)` in `src/config.rs` to centralize provisioner path resolution.
- Update `load_profile` to deserialize into a mutable `profile`, compute `profile_dir` with `path.parent().unwrap_or_else(|| Utf8Path::new("."))`, and call the new helper.
- Add unit test `test_load_profile_resolves_shell_script_relative_to_profile_dir` to `tests/config_test.rs` and adjust imports to include `ProvisionerConfig` and `tempdir` so relative `script` entries are resolved to the absolute path under the profile directory.

### Testing
- Ran `cargo test` and all unit tests and doctests passed, including `test_load_profile_resolves_shell_script_relative_to_profile_dir`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cfb1e1be483278498e947250cd21b)