### PR TITLE
Validate profile dir is a directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@
 //! The configuration is typically loaded from YAML files using the
 //! `load_profile` function.
 
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Ok, Result, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 use std::fs::File;
@@ -63,6 +63,9 @@ impl Bootstrap {
 impl Profile {
     /// Validate configuration semantics beyond basic deserialization.
     pub fn validate(&self) -> Result<()> {
+        if self.dir.exists() && !self.dir.is_dir() {
+            bail!("dir must be a directory: {}", self.dir);
+        }
         for (index, provisioner) in self.provisioners.iter().enumerate() {
             provisioner
                 .validate()

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -278,6 +278,32 @@ provisioners:
 }
 
 #[test]
+fn test_profile_validation_rejects_dir_file() -> Result<()> {
+    let dir_file = NamedTempFile::new()?;
+    let mut file = NamedTempFile::new()?;
+    // editorconfig-checker-disable
+    writeln!(
+        file,
+        r#"---
+dir: {}
+bootstrap:
+  type: mmdebstrap
+  suite: bookworm
+  target: rootfs.tar.zst
+"#,
+        dir_file.path().display()
+    )?;
+    // editorconfig-checker-enable
+
+    let path = Utf8Path::from_path(file.path()).unwrap();
+    let profile = load_profile(path)?;
+
+    assert!(profile.validate().is_err());
+
+    Ok(())
+}
+
+#[test]
 fn test_load_profile_resolves_shell_script_relative_to_profile_dir() -> Result<()> {
     let temp_dir = tempdir()?;
     let profile_path = temp_dir.path().join("profile.yml");


### PR DESCRIPTION
### Motivation
- Ensure a configured `dir` in a profile that already exists is a directory and not a regular file to avoid unexpected behavior during apply.
- Add a unit test to cover the error case when `dir` points at a file.

### Description
- Add a check in `Profile::validate` in `src/config.rs` to `bail!` when `self.dir.exists()` and `!self.dir.is_dir()`.
- Import `bail` from `anyhow` to produce a clear validation error message.
- Add `test_profile_validation_rejects_dir_file` to `tests/config_test.rs` which creates a temporary file, references it as `dir` in a profile, and asserts that `profile.validate()` returns an error.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo test` and the full test suite passed, including the new test `test_profile_validation_rejects_dir_file`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cfe20ccb483279288e71bb8d99713)