### PR TITLE
Validate shell provisioner script paths and update tests

### DIFF
--- a/src/provisioners/shell.rs
+++ b/src/provisioners/shell.rs
@@ -38,7 +38,16 @@ impl ShellProvisioner {
     /// Validates that exactly one of `script` or `content` is specified.
     pub fn validate(&self) -> Result<()> {
         match (&self.script, &self.content) {
-            (Some(_), None) | (None, Some(_)) => Ok(()),
+            (Some(script), None) => {
+                let metadata = fs::metadata(script).with_context(|| {
+                    format!("failed to read shell provisioner script metadata: {}", script)
+                })?;
+                if !metadata.is_file() {
+                    bail!("shell provisioner script is not a file: {}", script);
+                }
+                Ok(())
+            }
+            (None, Some(_)) => Ok(()),
             (Some(_), Some(_)) => {
                 bail!("shell provisioner cannot specify both 'script' and 'content'")
             }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -344,3 +344,33 @@ provisioners:
 
     Ok(())
 }
+
+#[test]
+fn test_shell_provisioner_validation_requires_script_file() -> Result<()> {
+    let temp_dir = tempdir()?;
+    let profile_path = temp_dir.path().join("profile.yml");
+
+    let mut file = std::fs::File::create(&profile_path)?;
+    // editorconfig-checker-disable
+    writeln!(
+        file,
+        r#"---
+dir: /tmp/test
+bootstrap:
+  type: mmdebstrap
+  suite: bookworm
+  target: rootfs.tar.zst
+provisioners:
+  - type: shell
+    script: scripts/missing.sh
+"#
+    )?;
+    // editorconfig-checker-enable
+
+    let path = Utf8Path::from_path(&profile_path).unwrap();
+    let profile = load_profile(path)?;
+
+    assert!(profile.validate().is_err());
+
+    Ok(())
+}

--- a/tests/provisioners_test.rs
+++ b/tests/provisioners_test.rs
@@ -1,4 +1,5 @@
 use rsdebstrap::provisioners::shell::ShellProvisioner;
+use tempfile::tempdir;
 
 fn default_shell() -> String {
     "/bin/sh".to_string()
@@ -26,8 +27,14 @@ fn test_validate_both_script_and_content() {
 
 #[test]
 fn test_validate_script_only() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let script_path = temp_dir.path().join("test.sh");
+    std::fs::write(&script_path, "#!/bin/sh\necho test\n").expect("failed to write script");
     let provisioner = ShellProvisioner {
-        script: Some("test.sh".into()),
+        script: Some(
+            camino::Utf8PathBuf::from_path_buf(script_path)
+                .expect("script path should be valid UTF-8"),
+        ),
         content: None,
         shell: default_shell(),
     };


### PR DESCRIPTION
### Motivation
- Ensure shell provisioner validation rejects missing or non-file `script` paths to avoid runtime failures and tighten security checks.

### Description
- Update `ShellProvisioner::validate()` to read filesystem metadata for `script` and return an error if the path cannot be read or is not a regular file by using `fs::metadata` and `metadata.is_file()`.
- Normalize the validation error message formatting for the shell provisioner path check.
- Update tests to exercise the stricter validation: add `test_shell_provisioner_validation_requires_script_file` in `tests/config_test.rs` and change `tests/provisioners_test.rs::test_validate_script_only` to create a real temporary script file and pass a `Utf8PathBuf`.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Ran `cargo test` and all unit tests completed successfully (including the new and updated tests) with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d011075288327a5059cad2c25c74e)