### PR TITLE
Refactor orchestration into library and add integration tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,86 @@ pub mod cli;
 pub mod config;
 pub mod executor;
 pub mod provisioners;
+
+use std::fs;
+
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+use tracing_subscriber::{FmtSubscriber, filter::LevelFilter};
+
+use crate::executor::CommandExecutor;
+
+pub fn init_logging(log_level: cli::LogLevel) -> Result<()> {
+    let filter = match log_level {
+        cli::LogLevel::Trace => LevelFilter::TRACE,
+        cli::LogLevel::Debug => LevelFilter::DEBUG,
+        cli::LogLevel::Info => LevelFilter::INFO,
+        cli::LogLevel::Warn => LevelFilter::WARN,
+        cli::LogLevel::Error => LevelFilter::ERROR,
+    };
+
+    tracing::subscriber::set_global_default(
+        FmtSubscriber::builder().with_max_level(filter).finish(),
+    )
+    .context("failed to set global default tracing subscriber")
+}
+
+pub fn run_apply(opts: &cli::ApplyArgs, executor: &dyn CommandExecutor) -> Result<()> {
+    let profile = config::load_profile(opts.file.as_path())
+        .with_context(|| format!("failed to load profile from {}", opts.file))?;
+    profile.validate().context("profile validation failed")?;
+
+    if !opts.dry_run && !profile.dir.exists() {
+        fs::create_dir_all(&profile.dir)
+            .with_context(|| format!("failed to create directory: {}", profile.dir))?;
+    }
+
+    // Bootstrap phase
+    let backend = profile.bootstrap.as_backend();
+    let command_name = backend.command_name();
+
+    let args = backend
+        .build_args(&profile.dir)
+        .with_context(|| format!("failed to build arguments for {}", command_name))?;
+
+    executor
+        .execute(command_name, &args)
+        .with_context(|| format!("failed to execute {}", command_name))?;
+
+    // Provisioning phase
+    if !profile.provisioners.is_empty() {
+        info!("starting provisioning phase with {} provisioner(s)", profile.provisioners.len());
+
+        // Determine rootfs path based on bootstrap configuration
+        match backend.rootfs_output(&profile.dir) {
+            Ok(backends::RootfsOutput::Directory(rootfs)) => {
+                for (index, provisioner_config) in profile.provisioners.iter().enumerate() {
+                    info!("running provisioner {}/{}", index + 1, profile.provisioners.len());
+                    let provisioner = provisioner_config.as_provisioner();
+                    provisioner
+                        .provision(&rootfs, executor, opts.dry_run)
+                        .with_context(|| format!("failed to run provisioner {}", index + 1))?;
+                }
+
+                info!("provisioning phase completed successfully");
+            }
+            Ok(backends::RootfsOutput::NonDirectory { reason }) => warn!(
+                "skipping provisioners: {}. \
+                Provisioners are only supported for directory-based bootstrap targets. \
+                For archive-based targets (tar, squashfs, etc.), \
+                consider using backend-specific hooks instead.",
+                reason
+            ),
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
+pub fn run_validate(opts: &cli::ValidateArgs) -> Result<()> {
+    let profile = config::load_profile(opts.file.as_path())?;
+    profile.validate().context("profile validation failed")?;
+    info!("validation successful:\n{:#?}", profile);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,9 @@
-mod backends;
-mod cli;
-mod config;
-mod executor;
-mod provisioners;
-
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::CommandFactory;
 use clap_complete::generate;
 use std::io;
-use tracing::{info, warn};
-use tracing_subscriber::FmtSubscriber;
-use tracing_subscriber::filter::LevelFilter;
 
-use crate::executor::CommandExecutor;
+use rsdebstrap::{cli, executor, init_logging, run_apply, run_validate};
 
 fn main() -> Result<()> {
     let args = cli::parse_args()?;
@@ -31,88 +22,17 @@ fn main() -> Result<()> {
         cli::Commands::Completions(_) => unreachable!("completions handled above"),
     };
 
-    let filter = match log_level {
-        cli::LogLevel::Trace => LevelFilter::TRACE,
-        cli::LogLevel::Debug => LevelFilter::DEBUG,
-        cli::LogLevel::Info => LevelFilter::INFO,
-        cli::LogLevel::Warn => LevelFilter::WARN,
-        cli::LogLevel::Error => LevelFilter::ERROR,
-    };
-
-    tracing::subscriber::set_global_default(
-        FmtSubscriber::builder().with_max_level(filter).finish(),
-    )
-    .expect("failed to set global default tracing subscriber");
+    init_logging(log_level)?;
 
     match &args.command {
         cli::Commands::Apply(opts) => {
-            let profile = config::load_profile(opts.file.as_path())
-                .with_context(|| format!("failed to load profile from {}", opts.file))?;
-            profile.validate().context("profile validation failed")?;
-
-            if !opts.dry_run && !profile.dir.exists() {
-                std::fs::create_dir_all(&profile.dir)
-                    .with_context(|| format!("failed to create directory: {}", profile.dir))?;
-            }
-
             let executor = executor::RealCommandExecutor {
                 dry_run: opts.dry_run,
             };
 
-            // Bootstrap phase
-            let backend = profile.bootstrap.as_backend();
-            let command_name = backend.command_name();
-
-            let args = backend
-                .build_args(&profile.dir)
-                .with_context(|| format!("failed to build arguments for {}", command_name))?;
-
-            executor
-                .execute(command_name, &args)
-                .with_context(|| format!("failed to execute {}", command_name))?;
-
-            // Provisioning phase
-            if !profile.provisioners.is_empty() {
-                info!(
-                    "starting provisioning phase with {} provisioner(s)",
-                    profile.provisioners.len()
-                );
-
-                // Determine rootfs path based on bootstrap configuration
-                match backend.rootfs_output(&profile.dir) {
-                    Ok(backends::RootfsOutput::Directory(rootfs)) => {
-                        for (index, provisioner_config) in profile.provisioners.iter().enumerate() {
-                            info!(
-                                "running provisioner {}/{}",
-                                index + 1,
-                                profile.provisioners.len()
-                            );
-                            let provisioner = provisioner_config.as_provisioner();
-                            provisioner
-                                .provision(&rootfs, &executor, opts.dry_run)
-                                .with_context(|| {
-                                    format!("failed to run provisioner {}", index + 1)
-                                })?;
-                        }
-
-                        info!("provisioning phase completed successfully");
-                    }
-                    Ok(backends::RootfsOutput::NonDirectory { reason }) => warn!(
-                        "skipping provisioners: {}. \
-                        Provisioners are only supported for directory-based bootstrap targets. \
-                        For archive-based targets (tar, squashfs, etc.), \
-                        consider using backend-specific hooks instead.",
-                        reason
-                    ),
-                    Err(e) => return Err(e),
-                }
-            }
+            run_apply(opts, &executor)?;
         }
-        cli::Commands::Validate(opts) => {
-            let profile = config::load_profile(opts.file.as_path())?;
-            profile.validate().context("profile validation failed")?;
-            info!("validation successful:\n{:#?}", profile);
-        }
+        cli::Commands::Validate(opts) => run_validate(opts)?,
         cli::Commands::Completions(_) => {
             unreachable!("completions handled earlier");
         }

--- a/tests/orchestration_test.rs
+++ b/tests/orchestration_test.rs
@@ -1,0 +1,46 @@
+use std::cell::RefCell;
+use std::ffi::OsString;
+
+use rsdebstrap::{cli, executor::CommandExecutor, run_apply, run_validate};
+
+#[derive(Default)]
+struct RecordingExecutor {
+    calls: RefCell<Vec<(String, Vec<OsString>)>>,
+}
+
+impl CommandExecutor for RecordingExecutor {
+    fn execute(&self, command: &str, args: &[OsString]) -> anyhow::Result<()> {
+        self.calls
+            .borrow_mut()
+            .push((command.to_string(), args.to_vec()));
+        Ok(())
+    }
+}
+
+#[test]
+fn run_apply_uses_executor_with_built_args() {
+    let opts = cli::ApplyArgs {
+        file: "examples/debian_trixie_mmdebstrap.yml".into(),
+        log_level: cli::LogLevel::Error,
+        dry_run: true,
+    };
+    let executor = RecordingExecutor::default();
+
+    run_apply(&opts, &executor).expect("run_apply should succeed");
+
+    let calls = executor.calls.borrow();
+    assert_eq!(calls.len(), 1);
+    let (command, args) = calls.first().expect("at least one call");
+    assert_eq!(command, "mmdebstrap");
+    assert!(!args.is_empty(), "expected args to be populated");
+}
+
+#[test]
+fn run_validate_succeeds_on_valid_profile() {
+    let opts = cli::ValidateArgs {
+        file: "examples/debian_trixie_mmdebstrap.yml".into(),
+        log_level: cli::LogLevel::Error,
+    };
+
+    run_validate(&opts).expect("run_validate should succeed for sample profile");
+}


### PR DESCRIPTION
- move orchestration flow into a reusable library entry point
- add logging initializer and adjust CLI to use it
- cover end-to-end behavior with new integration tests
- preserve existing CLI behavior while improving testability
