### PR TITLE
Resolve relative output directory paths in profiles

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -159,11 +159,24 @@ fn resolve_profile_paths(profile: &mut Profile, profile_dir: &Utf8Path) {
 /// ```
 #[tracing::instrument]
 pub fn load_profile(path: &Utf8Path) -> Result<Profile> {
-    let file = File::open(path).with_context(|| format!("failed to load file: {}", path))?;
+    // Canonicalize the entire path first to resolve all symlinks and get the true absolute path.
+    // This ensures relative paths in the profile are resolved relative to the actual file location,
+    // not the symlink location.
+    let canonical_path = path
+        .canonicalize_utf8()
+        .with_context(|| format!("failed to canonicalize path: {}", path))?;
+
+    let file = File::open(&canonical_path)
+        .with_context(|| format!("failed to load file: {}", canonical_path))?;
     let reader = BufReader::new(file);
     let mut profile: Profile = serde_yaml::from_reader(reader)
-        .with_context(|| format!("failed to parse yaml: {}", path))?;
-    let profile_dir = path.parent().unwrap_or_else(|| Utf8Path::new("."));
+        .with_context(|| format!("failed to parse yaml: {}", canonical_path))?;
+
+    // While parent() should always return Some for canonical file paths,
+    // we handle None for defensive programming
+    let profile_dir = canonical_path.parent().with_context(|| {
+        format!("could not determine parent directory of profile path: {}", canonical_path)
+    })?;
     resolve_profile_paths(&mut profile, profile_dir);
     debug!("loaded profile:\n{:#?}", profile);
     Ok(profile)

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -366,6 +366,68 @@ provisioners:
     Ok(())
 }
 
+#[test]
+fn test_shell_provisioner_path_resolution_with_relative_profile_path() -> Result<()> {
+    // Acquire global lock to prevent parallel CWD modifications
+    let _lock = helpers::CWD_TEST_LOCK.lock().unwrap();
+
+    let temp_dir = tempdir()?;
+    let profile_dir = temp_dir.path().join("configs");
+    let scripts_dir = profile_dir.join("scripts");
+    std::fs::create_dir_all(&scripts_dir)?;
+
+    // Create a dummy script file
+    let script_path = scripts_dir.join("test.sh");
+    std::fs::write(&script_path, "#!/bin/bash\necho test")?;
+
+    // Create profile YAML with relative script path
+    let profile_path = profile_dir.join("profile.yml");
+    // editorconfig-checker-disable
+    std::fs::write(
+        &profile_path,
+        crate::yaml!(
+            r#"---
+dir: /tmp/test
+bootstrap:
+  type: mmdebstrap
+  suite: bookworm
+  target: rootfs
+  format: directory
+provisioners:
+  - type: shell
+    script: scripts/test.sh
+"#
+        ),
+    )?;
+    // editorconfig-checker-enable
+
+    // Use RAII guard to automatically restore working directory
+    let cwd_guard = helpers::CwdGuard::new()?;
+    cwd_guard.change_to(temp_dir.path())?;
+
+    // Load profile using relative path from the new working directory
+    let relative_profile_path = Utf8Path::new("configs/profile.yml");
+    let profile = load_profile(relative_profile_path)?;
+
+    // CwdGuard will automatically restore the original directory when dropped
+
+    // Verify the script path resolves to the expected absolute path
+    let expected_script_path =
+        Utf8PathBuf::from_path_buf(script_path).expect("script path should be valid UTF-8");
+    match &profile.provisioners[..] {
+        [ProvisionerConfig::Shell(shell)] => {
+            let script = shell.script.as_ref().expect("script should be set");
+            assert_eq!(
+                script, &expected_script_path,
+                "Script path should resolve to the expected absolute path"
+            );
+        }
+        _ => panic!("expected one shell provisioner"),
+    }
+
+    Ok(())
+}
+
 /// Helper function to test provisioner validation rejection with non-directory output
 fn test_provisioner_validation_rejects_target(target: &str) -> Result<()> {
     // editorconfig-checker-disable


### PR DESCRIPTION
### Motivation
- Profiles that specify a relative `dir` were left as-is, causing output paths to depend on the process CWD instead of the profile file location, which is surprising and error-prone.
- Shell provisioner `script` paths were already resolved relative to the profile; `dir` should be resolved the same way for consistency.

### Description

#### Core Changes
- Rename `resolve_provisioner_paths` to `resolve_profile_paths` and update callers accordingly.
- When loading a profile, if `Profile::dir` is a relative path, resolve it against the directory containing the profile file (`profile_dir.join(&profile.dir)`).
- Preserve existing behavior of resolving relative shell provisioner `script` paths against the profile directory.

#### Path Resolution Improvements
- Canonicalize the profile path before extracting the parent directory to correctly handle symlinked profiles - this ensures relative paths are resolved against the actual file location, not the symlink location.
- Improve error handling with `with_context` for profile directory resolution failures.

#### Test Infrastructure
- Add `CwdGuard` RAII helper in `tests/helpers/mod.rs` for safely changing and restoring the current working directory in tests.
- Add `CWD_TEST_LOCK` global mutex to prevent parallel tests from interfering when they modify the working directory.

### Testing
Added comprehensive test coverage:
- `test_load_profile_resolves_dir_relative_to_profile_dir` - verifies relative `dir` values are resolved against the profile file location
- `test_shell_provisioner_path_resolution_with_relative_profile_path` - tests path resolution when the profile itself is loaded via a relative path

All tests pass: `cargo test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5753c9b0832793db3346236978ad)