### PR TITLE
fix: remove needless borrows for generic args in tests

### DIFF
--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -245,7 +245,7 @@ provisioners:
 fn test_profile_validation_rejects_dir_file() -> Result<()> {
     let dir_file = tempfile::NamedTempFile::new()?;
     // editorconfig-checker-disable
-    let profile = helpers::load_profile_from_yaml(&format!(
+    let profile = helpers::load_profile_from_yaml(format!(
         r#"---
 dir: {}
 bootstrap:
@@ -431,7 +431,7 @@ provisioners:
 /// Helper function to test provisioner validation rejection with non-directory output
 fn test_provisioner_validation_rejects_target(target: &str) -> Result<()> {
     // editorconfig-checker-disable
-    let profile = helpers::load_profile_from_yaml(&format!(
+    let profile = helpers::load_profile_from_yaml(format!(
         r#"---
 dir: /tmp/test
 bootstrap:


### PR DESCRIPTION
## Summary
- Remove unnecessary `&` references when calling `load_profile_from_yaml` with `format!()` results
- The function accepts `AsRef<str>`, so `String` can be passed directly without borrowing
- Fixes `clippy::needless_borrows_for_generic_args` warnings

## Test plan
- [x] `cargo clippy --tests` passes without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)