### PR TITLE
chore: add git and gh commands to claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,17 @@
 			"Bash(cargo r:*)",
 			"Bash(cargo run:*)",
 			"Bash(cargo t:*)",
-			"Bash(cargo test:*)"
+			"Bash(cargo test:*)",
+			"Bash(gh pr create:*)",
+			"Bash(gh pr diff:*)",
+			"Bash(gh pr edit:*)",
+			"Bash(gh pr list:*)",
+			"Bash(gh pr view:*)",
+			"Bash(git add:*)",
+			"Bash(git checkout:*)",
+			"Bash(git commit:*)",
+			"Bash(git push:*)",
+			"Bash(git show:*)"
 		],
 		"deny": []
 	}


### PR DESCRIPTION
## Summary
- git/ghコマンドの許可設定を `.claude/settings.json` に追加
  - `gh pr create/diff/edit/list/view`
  - `git add/checkout/commit/push/show`

## Test plan
- [x] 設定ファイルのJSON構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)