### PR TITLE
feat: add explicit warning message when running in dry-run mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::{FmtSubscriber, filter::LevelFilter};
 
 use crate::executor::CommandExecutor;
@@ -90,6 +90,10 @@ fn run_pipeline_phase(
 }
 
 pub fn run_apply(opts: &cli::ApplyArgs, executor: Arc<dyn CommandExecutor>) -> Result<()> {
+    if opts.dry_run {
+        warn!("DRY-RUN MODE: No changes will be made");
+    }
+
     let profile = config::load_profile(opts.file.as_path())
         .with_context(|| format!("failed to load profile from {}", opts.file))?;
     profile.validate().context("profile validation failed")?;


### PR DESCRIPTION
## Summary
- Add a `warn!` log message at the start of `run_apply()` when `--dry-run` flag is specified
- Users now see `DRY-RUN MODE: No changes will be made` warning, making it clear that no modifications will occur

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all tests pass (no regressions)
- [ ] Manual verification: `cargo run -- apply -f examples/debian_trixie_mmdebstrap.yml --dry-run` displays warning

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)