### PR TITLE
refactor: extract common patterns into reusable methods

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -186,12 +186,9 @@ impl Profile {
         // (e.g., a non-RsdebstrapError from a backend), we fall back to Validation.
         if !pipeline.is_empty() {
             let backend = self.bootstrap.as_backend();
-            let output = backend.rootfs_output(&self.dir).map_err(|e| {
-                match e.downcast::<RsdebstrapError>() {
-                    Ok(typed_err) => typed_err,
-                    Err(e) => RsdebstrapError::Validation(format!("{:#}", e)),
-                }
-            })?;
+            let output = backend
+                .rootfs_output(&self.dir)
+                .map_err(RsdebstrapError::from_anyhow_or_validation)?;
             if let RootfsOutput::NonDirectory { reason } = output {
                 return Err(RsdebstrapError::Validation(format!(
                     "pipeline tasks require directory output but got: {}. \

--- a/src/task/mitamae.rs
+++ b/src/task/mitamae.rs
@@ -122,11 +122,7 @@ impl MitamaeTask {
         {
             *binary = base_dir.join(&*binary);
         }
-        if let ScriptSource::Script(path) = &mut self.source
-            && path.is_relative()
-        {
-            *path = base_dir.join(&*path);
-        }
+        self.source.resolve_paths(base_dir);
     }
 
     /// Resolves the privilege setting against profile defaults.

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -121,6 +121,18 @@ impl ScriptSource {
         }
     }
 
+    /// Resolves relative script paths relative to the given base directory.
+    ///
+    /// If the source is an external script file with a relative path,
+    /// it is resolved against `base_dir`. Content sources are unchanged.
+    pub fn resolve_paths(&mut self, base_dir: &Utf8Path) {
+        if let Self::Script(path) = self
+            && path.is_relative()
+        {
+            *path = base_dir.join(&*path);
+        }
+    }
+
     /// Validates the script source.
     ///
     /// The `label` parameter is used in error messages to distinguish between

--- a/src/task/shell.rs
+++ b/src/task/shell.rs
@@ -124,11 +124,7 @@ impl ShellTask {
 
     /// Resolves relative paths in this task relative to the given base directory.
     pub fn resolve_paths(&mut self, base_dir: &Utf8Path) {
-        if let ScriptSource::Script(path) = &mut self.source
-            && path.is_relative()
-        {
-            *path = base_dir.join(&*path);
-        }
+        self.source.resolve_paths(base_dir);
     }
 
     /// Resolves the privilege setting against profile defaults.


### PR DESCRIPTION
## Summary
- Extract `RsdebstrapError::from_anyhow_or_validation()` to encapsulate the recurring anyhow-to-typed-error conversion pattern (downcast or wrap as `Validation`)
- Extract `ScriptSource::resolve_paths()` to eliminate duplicated relative path resolution logic in `ShellTask` and `MitamaeTask`

## Test plan
- [x] `cargo test --quiet` — all 336 tests pass
- [x] `cargo clippy --all-targets --all-features --quiet` — no warnings
- [x] `cargo fmt --all -- --check` — formatting clean
- [x] New unit tests for `from_anyhow_or_validation()` cover both typed preservation and generic wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)