### PR TITLE
refactor: extract modules and deduplicate shared patterns

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1,0 +1,62 @@
+//! Bootstrap backend configuration enum.
+
+use serde::Deserialize;
+
+use super::BootstrapBackend;
+use super::debootstrap::DebootstrapConfig;
+use super::mmdebstrap::MmdebstrapConfig;
+use crate::error::RsdebstrapError;
+use crate::privilege::{Privilege, PrivilegeDefaults, PrivilegeMethod};
+
+/// Bootstrap backend configuration.
+///
+/// This enum represents the different bootstrap tools that can be used.
+/// The `type` field in YAML determines which variant is used.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Bootstrap {
+    /// mmdebstrap backend
+    Mmdebstrap(MmdebstrapConfig),
+    /// debootstrap backend
+    Debootstrap(DebootstrapConfig),
+}
+
+impl Bootstrap {
+    /// Returns a reference to the underlying backend as a trait object.
+    ///
+    /// This allows calling `BootstrapBackend` methods without matching
+    /// on each variant explicitly.
+    pub fn as_backend(&self) -> &dyn BootstrapBackend {
+        match self {
+            Bootstrap::Mmdebstrap(cfg) => cfg,
+            Bootstrap::Debootstrap(cfg) => cfg,
+        }
+    }
+
+    /// Returns a reference to the privilege setting of the bootstrap backend.
+    pub fn privilege(&self) -> &Privilege {
+        match self {
+            Bootstrap::Mmdebstrap(cfg) => &cfg.privilege,
+            Bootstrap::Debootstrap(cfg) => &cfg.privilege,
+        }
+    }
+
+    /// Resolves the privilege setting against profile defaults, replacing
+    /// the stored `Privilege` with a fully resolved variant.
+    pub fn resolve_privilege(
+        &mut self,
+        defaults: Option<&PrivilegeDefaults>,
+    ) -> Result<(), RsdebstrapError> {
+        match self {
+            Bootstrap::Mmdebstrap(cfg) => cfg.privilege.resolve_in_place(defaults),
+            Bootstrap::Debootstrap(cfg) => cfg.privilege.resolve_in_place(defaults),
+        }
+    }
+
+    /// Returns the resolved privilege method for the bootstrap backend.
+    ///
+    /// Should only be called after `resolve_privilege()`.
+    pub fn resolved_privilege_method(&self) -> Option<PrivilegeMethod> {
+        self.privilege().resolved_method()
+    }
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -7,10 +7,12 @@ use anyhow::Result;
 use url::Url;
 
 mod args;
+pub mod config;
 pub mod debootstrap;
 pub mod mmdebstrap;
 
 pub use args::{CommandArgsBuilder, FlagValueStyle};
+pub use config::Bootstrap;
 
 /// Output classification for pipeline task rootfs usage.
 #[derive(Debug)]

--- a/src/isolation/chroot.rs
+++ b/src/isolation/chroot.rs
@@ -66,12 +66,7 @@ impl IsolationContext for ChrootContext {
         command: &[String],
         privilege: Option<PrivilegeMethod>,
     ) -> Result<ExecutionResult> {
-        if self.torn_down {
-            return Err(crate::error::RsdebstrapError::Isolation(
-                "cannot execute command: chroot context has already been torn down".to_string(),
-            )
-            .into());
-        }
+        super::check_not_torn_down(self.torn_down, "chroot")?;
 
         let mut args: Vec<String> = Vec::with_capacity(command.len() + 1);
         args.push(self.rootfs.to_string());

--- a/src/isolation/config.rs
+++ b/src/isolation/config.rs
@@ -1,0 +1,32 @@
+//! Isolation backend configuration.
+
+use serde::{Deserialize, Serialize};
+
+use super::ChrootProvider;
+use super::IsolationProvider;
+
+/// Isolation backend configuration.
+///
+/// This enum represents the different isolation mechanisms that can be used
+/// to execute commands within a rootfs. The `type` field in YAML determines
+/// which variant is used. If not specified, defaults to chroot.
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum IsolationConfig {
+    /// chroot isolation (default)
+    #[default]
+    Chroot,
+    // Future: Bwrap(BwrapConfig), Nspawn(NspawnConfig)
+}
+
+impl IsolationConfig {
+    /// Returns a boxed isolation provider instance.
+    ///
+    /// This allows calling `IsolationProvider` methods without matching
+    /// on each variant explicitly.
+    pub fn as_provider(&self) -> Box<dyn IsolationProvider> {
+        match self {
+            IsolationConfig::Chroot => Box::new(ChrootProvider),
+        }
+    }
+}

--- a/src/isolation/direct.rs
+++ b/src/isolation/direct.rs
@@ -74,12 +74,7 @@ impl IsolationContext for DirectContext {
         command: &[String],
         privilege: Option<PrivilegeMethod>,
     ) -> Result<ExecutionResult> {
-        if self.torn_down {
-            return Err(crate::error::RsdebstrapError::Isolation(
-                "cannot execute command: direct context has already been torn down".to_string(),
-            )
-            .into());
-        }
+        super::check_not_torn_down(self.torn_down, "direct")?;
 
         if command.is_empty() {
             return Err(crate::error::RsdebstrapError::Isolation(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod executor;
 pub mod isolation;
 pub mod pipeline;
 pub mod privilege;
+pub(crate) mod serde_helpers;
 pub mod task;
 
 pub use error::RsdebstrapError;
@@ -19,14 +20,20 @@ use tracing_subscriber::{FmtSubscriber, filter::LevelFilter};
 
 use crate::executor::CommandExecutor;
 
+impl From<cli::LogLevel> for LevelFilter {
+    fn from(level: cli::LogLevel) -> Self {
+        match level {
+            cli::LogLevel::Trace => LevelFilter::TRACE,
+            cli::LogLevel::Debug => LevelFilter::DEBUG,
+            cli::LogLevel::Info => LevelFilter::INFO,
+            cli::LogLevel::Warn => LevelFilter::WARN,
+            cli::LogLevel::Error => LevelFilter::ERROR,
+        }
+    }
+}
+
 pub fn init_logging(log_level: cli::LogLevel) -> Result<()> {
-    let filter = match log_level {
-        cli::LogLevel::Trace => LevelFilter::TRACE,
-        cli::LogLevel::Debug => LevelFilter::DEBUG,
-        cli::LogLevel::Info => LevelFilter::INFO,
-        cli::LogLevel::Warn => LevelFilter::WARN,
-        cli::LogLevel::Error => LevelFilter::ERROR,
-    };
+    let filter = LevelFilter::from(log_level);
 
     tracing::subscriber::set_global_default(
         FmtSubscriber::builder().with_max_level(filter).finish(),

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -1,0 +1,101 @@
+//! Shared serde helpers for `Inherit`/`UseDefault`/`Disabled`/explicit enum patterns.
+
+/// Implements `Deserialize` and `Serialize` for enums with the
+/// `Inherit` / `UseDefault` / `Disabled` / explicit-variant pattern.
+///
+/// The enum must have exactly four variants:
+/// - `Inherit` — maps to YAML `null`/absent
+/// - `UseDefault` — maps to YAML `true`
+/// - `Disabled` — maps to YAML `false`
+/// - An explicit variant — maps to a YAML map
+///
+/// # Parameters
+///
+/// - `$type`: The enum type name
+/// - `$explicit`: The name of the explicit variant (e.g., `Method`, `Config`)
+/// - `$expecting`: A human-readable description for error messages
+/// - `$map_ident`: Identifier bound to the `MapAccess` in `visit_map`
+/// - `$deser_body`: Expression block for `visit_map` that returns `Result<$type, A::Error>`
+/// - `$val_ident`: Identifier bound to the inner value of the explicit variant during serialization
+/// - `$ser_ident`: Identifier bound to the `Serializer`
+/// - `$ser_body`: Expression block for serializing the explicit variant
+macro_rules! impl_inherit_or_explicit_serde {
+    (
+        $type:ident,
+        explicit: $explicit:ident,
+        expecting: $expecting:expr,
+        deserialize_map($map_ident:ident) $deser_body:block,
+        serialize_explicit($val_ident:ident, $ser_ident:ident) $ser_body:block
+    ) => {
+        impl<'de> ::serde::Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                use ::serde::de;
+
+                struct InheritVisitor;
+
+                impl<'de> de::Visitor<'de> for InheritVisitor {
+                    type Value = $type;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::std::fmt::Formatter<'_>,
+                    ) -> ::std::fmt::Result {
+                        formatter.write_str($expecting)
+                    }
+
+                    fn visit_unit<E>(self) -> ::std::result::Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Ok($type::Inherit)
+                    }
+
+                    fn visit_bool<E>(self, v: bool) -> ::std::result::Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        if v {
+                            Ok($type::UseDefault)
+                        } else {
+                            Ok($type::Disabled)
+                        }
+                    }
+
+                    fn visit_map<A>(
+                        self,
+                        $map_ident: A,
+                    ) -> ::std::result::Result<Self::Value, A::Error>
+                    where
+                        A: de::MapAccess<'de>,
+                    {
+                        $deser_body
+                    }
+                }
+
+                deserializer.deserialize_any(InheritVisitor)
+            }
+        }
+
+        impl ::serde::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                match self {
+                    Self::Inherit => serializer.serialize_none(),
+                    Self::UseDefault => serializer.serialize_bool(true),
+                    Self::Disabled => serializer.serialize_bool(false),
+                    Self::$explicit($val_ident) => {
+                        let $ser_ident = serializer;
+                        $ser_body
+                    }
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_inherit_or_explicit_serde;

--- a/src/task/execution.rs
+++ b/src/task/execution.rs
@@ -1,0 +1,87 @@
+//! Execution utilities for task command dispatch.
+//!
+//! Provides command execution within isolation contexts and
+//! execution result checking.
+
+use anyhow::Result;
+
+use crate::error::RsdebstrapError;
+use crate::executor::ExecutionResult;
+use crate::isolation::IsolationContext;
+use crate::privilege::PrivilegeMethod;
+
+/// Executes a command within an isolation context, preserving `RsdebstrapError` variants.
+///
+/// If the context returns an `anyhow::Error` that wraps a `RsdebstrapError`, the typed
+/// error is preserved. Otherwise, the error is wrapped with a descriptive context message.
+///
+/// # Arguments
+///
+/// * `context` - The isolation context to execute within
+/// * `command` - The command and arguments to execute
+/// * `task_label` - Human-readable label used in error messages
+/// * `privilege` - Optional privilege escalation method (`sudo`/`doas`) to wrap the command
+pub(crate) fn execute_in_context(
+    context: &dyn IsolationContext,
+    command: &[String],
+    task_label: &str,
+    privilege: Option<PrivilegeMethod>,
+) -> Result<ExecutionResult> {
+    context
+        .execute(command, privilege)
+        .map_err(|e| match e.downcast::<RsdebstrapError>() {
+            Ok(typed) => typed.into(),
+            Err(e) => e.context(format!("failed to execute {}", task_label)),
+        })
+}
+
+/// Executes a command within an isolation context and checks the result.
+///
+/// Combines [`execute_in_context()`] and [`check_execution_result()`] into
+/// a single call, since these two operations always occur together in task
+/// execution flows.
+///
+/// # Arguments
+///
+/// * `context` - The isolation context to execute within
+/// * `command` - The command and arguments to execute
+/// * `task_label` - Human-readable label used in error messages
+/// * `privilege` - Optional privilege escalation method (`sudo`/`doas`) to wrap the command
+pub(crate) fn execute_and_check(
+    context: &dyn IsolationContext,
+    command: &[String],
+    task_label: &str,
+    privilege: Option<PrivilegeMethod>,
+) -> Result<()> {
+    let result = execute_in_context(context, command, task_label, privilege)?;
+    check_execution_result(&result, command, context.name(), context.dry_run())
+}
+
+/// Checks the execution result and returns an error if the command failed.
+///
+/// Handles three cases:
+/// - Non-zero exit status: returns `Execution` error with the status code
+/// - No exit status in non-dry-run mode: returns `Execution` error (e.g., killed by signal)
+/// - Success or dry-run with no status: returns `Ok(())`
+pub(crate) fn check_execution_result(
+    result: &ExecutionResult,
+    command: &[String],
+    context_name: &str,
+    dry_run: bool,
+) -> Result<()> {
+    match result.status {
+        Some(status) if !status.success() => {
+            Err(
+                RsdebstrapError::execution_in_isolation(command, context_name, status.to_string())
+                    .into(),
+            )
+        }
+        None if !dry_run => Err(RsdebstrapError::execution_in_isolation(
+            command,
+            context_name,
+            "process exited without status (possibly killed by signal)",
+        )
+        .into()),
+        _ => Ok(()),
+    }
+}

--- a/src/task/file_ops.rs
+++ b/src/task/file_ops.rs
@@ -1,0 +1,102 @@
+//! File operation utilities for task execution.
+//!
+//! Provides RAII temporary file cleanup, file copying/writing with
+//! permission management, and TOCTOU-mitigated file preparation.
+
+use std::fs;
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use tracing::info;
+
+use super::ScriptSource;
+use super::validation::validate_tmp_directory;
+
+/// RAII guard to ensure temporary file cleanup even on error.
+pub(crate) struct TempFileGuard {
+    path: Utf8PathBuf,
+    dry_run: bool,
+}
+
+impl TempFileGuard {
+    pub(crate) fn new(path: Utf8PathBuf, dry_run: bool) -> Self {
+        Self { path, dry_run }
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if !self.dry_run {
+            match fs::remove_file(&self.path) {
+                Ok(()) => tracing::debug!("cleaned up temp file: {}", self.path),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    tracing::debug!("temp file already removed: {}", self.path);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        path = %self.path,
+                        error_kind = ?e.kind(),
+                        "failed to cleanup temp file: {}",
+                        e,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Sets Unix file permissions on the given path.
+#[cfg(unix)]
+pub(crate) fn set_file_mode(path: &Utf8Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)
+        .with_context(|| format!("failed to read metadata for {}", path))?
+        .permissions();
+    perms.set_mode(mode);
+    fs::set_permissions(path, perms)
+        .with_context(|| format!("failed to set permissions on {}", path))?;
+    Ok(())
+}
+
+/// Copies or writes a script source to the target path and sets permissions.
+///
+/// On Unix systems, sets the file mode to the specified `mode`.
+/// On other platforms, the permission step is skipped.
+pub(crate) fn prepare_source_file(
+    source: &ScriptSource,
+    target: &Utf8Path,
+    mode: u32,
+    label: &str,
+) -> Result<()> {
+    match source {
+        ScriptSource::Script(src_path) => {
+            info!("copying {} from {} to rootfs", label, src_path);
+            fs::copy(src_path, target)
+                .with_context(|| format!("failed to copy {} {} to {}", label, src_path, target))?;
+        }
+        ScriptSource::Content(content) => {
+            info!("writing inline {} to rootfs", label);
+            fs::write(target, content)
+                .with_context(|| format!("failed to write inline {} to {}", label, target))?;
+        }
+    }
+    #[cfg(unix)]
+    set_file_mode(target, mode)?;
+    Ok(())
+}
+
+/// Re-validates `/tmp` (TOCTOU mitigation) and runs the file preparation closure.
+///
+/// In dry-run mode, skips both validation and file preparation entirely.
+pub(crate) fn prepare_files_with_toctou_check(
+    rootfs: &Utf8Path,
+    dry_run: bool,
+    prepare_fn: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    if !dry_run {
+        validate_tmp_directory(rootfs)
+            .context("TOCTOU check: /tmp validation failed before writing files")?;
+        prepare_fn()?;
+    }
+    Ok(())
+}

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -13,69 +13,34 @@
 //!
 //! The compiler enforces exhaustiveness, ensuring all task types are handled.
 
+pub(crate) mod execution;
+pub(crate) mod file_ops;
 pub mod mitamae;
 pub mod shell;
+pub(crate) mod validation;
 
 use std::borrow::Cow;
-use std::fs;
 
-use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
-use tracing::info;
 
 pub use mitamae::MitamaeTask;
 pub use shell::ShellTask;
 
-use crate::config::IsolationConfig;
 use crate::error::RsdebstrapError;
-use crate::executor::ExecutionResult;
+use crate::isolation::IsolationConfig;
 use crate::isolation::IsolationContext;
-use crate::privilege::{PrivilegeDefaults, PrivilegeMethod};
+use crate::privilege::PrivilegeDefaults;
 
-/// Validates that a path contains no `..` components.
-///
-/// Returns `RsdebstrapError::Validation` if any parent directory component is found.
-/// The `label` parameter is used in error messages to describe the path's purpose
-/// (e.g., "shell script", "mitamae binary").
-pub(crate) fn validate_no_parent_dirs(path: &Utf8Path, label: &str) -> Result<(), RsdebstrapError> {
-    if path
-        .components()
-        .any(|c| c == camino::Utf8Component::ParentDir)
-    {
-        return Err(RsdebstrapError::Validation(format!(
-            "{} path '{}' contains '..' components, \
-            which is not allowed for security reasons",
-            label, path
-        )));
-    }
-    Ok(())
-}
-
-/// Validates that a host-side file exists and is a regular file (not a symlink).
-///
-/// Uses `symlink_metadata` to avoid following symlinks. Returns
-/// `RsdebstrapError::Io` if the file cannot be accessed, or
-/// `RsdebstrapError::Validation` if the path is a symlink or not a regular file.
-/// The `label` parameter is used in error messages (e.g., "shell script", "mitamae binary").
-pub(crate) fn validate_host_file_exists(
-    path: &Utf8Path,
-    label: &str,
-) -> Result<(), RsdebstrapError> {
-    let metadata = fs::symlink_metadata(path).map_err(|e| {
-        RsdebstrapError::io(format!("failed to read {} metadata: {}", label, path), e)
-    })?;
-    if metadata.is_symlink() {
-        return Err(RsdebstrapError::Validation(format!(
-            "{} path '{}' is a symlink, which is not allowed for security reasons",
-            label, path
-        )));
-    }
-    if !metadata.is_file() {
-        return Err(RsdebstrapError::Validation(format!("{} is not a file: {}", label, path)));
-    }
-    Ok(())
-}
+// Re-export submodule items for convenient super:: access from shell.rs and mitamae.rs
+pub(crate) use execution::execute_and_check;
+#[cfg(unix)]
+pub(crate) use file_ops::set_file_mode;
+pub(crate) use file_ops::{TempFileGuard, prepare_files_with_toctou_check, prepare_source_file};
+pub(crate) use validation::{
+    validate_host_file_exists, validate_no_parent_dirs, validate_shell_in_rootfs,
+    validate_tmp_directory,
+};
 
 /// Resolves `script`/`content` mutual exclusivity and builds a [`ScriptSource`].
 ///
@@ -157,195 +122,6 @@ impl ScriptSource {
     }
 }
 
-/// RAII guard to ensure temporary file cleanup even on error.
-pub(crate) struct TempFileGuard {
-    path: Utf8PathBuf,
-    dry_run: bool,
-}
-
-impl TempFileGuard {
-    pub(crate) fn new(path: Utf8PathBuf, dry_run: bool) -> Self {
-        Self { path, dry_run }
-    }
-}
-
-impl Drop for TempFileGuard {
-    fn drop(&mut self) {
-        if !self.dry_run {
-            match fs::remove_file(&self.path) {
-                Ok(()) => tracing::debug!("cleaned up temp file: {}", self.path),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    tracing::debug!("temp file already removed: {}", self.path);
-                }
-                Err(e) => {
-                    tracing::error!(
-                        path = %self.path,
-                        error_kind = ?e.kind(),
-                        "failed to cleanup temp file: {}",
-                        e,
-                    );
-                }
-            }
-        }
-    }
-}
-
-/// Sets Unix file permissions on the given path.
-#[cfg(unix)]
-pub(crate) fn set_file_mode(path: &Utf8Path, mode: u32) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = fs::metadata(path)
-        .with_context(|| format!("failed to read metadata for {}", path))?
-        .permissions();
-    perms.set_mode(mode);
-    fs::set_permissions(path, perms)
-        .with_context(|| format!("failed to set permissions on {}", path))?;
-    Ok(())
-}
-
-/// Copies or writes a script source to the target path and sets permissions.
-///
-/// On Unix systems, sets the file mode to the specified `mode`.
-/// On other platforms, the permission step is skipped.
-pub(crate) fn prepare_source_file(
-    source: &ScriptSource,
-    target: &Utf8Path,
-    mode: u32,
-    label: &str,
-) -> Result<()> {
-    match source {
-        ScriptSource::Script(src_path) => {
-            info!("copying {} from {} to rootfs", label, src_path);
-            fs::copy(src_path, target)
-                .with_context(|| format!("failed to copy {} {} to {}", label, src_path, target))?;
-        }
-        ScriptSource::Content(content) => {
-            info!("writing inline {} to rootfs", label);
-            fs::write(target, content)
-                .with_context(|| format!("failed to write inline {} to {}", label, target))?;
-        }
-    }
-    #[cfg(unix)]
-    set_file_mode(target, mode)?;
-    Ok(())
-}
-
-/// Validates that /tmp exists as a real directory (not a symlink).
-///
-/// This is a security-critical check to prevent attackers from using symlinks
-/// to write files outside the chroot.
-pub(crate) fn validate_tmp_directory(rootfs: &Utf8Path) -> Result<()> {
-    let tmp_dir = rootfs.join("tmp");
-    let metadata = match std::fs::symlink_metadata(&tmp_dir) {
-        Ok(metadata) => metadata,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(RsdebstrapError::Validation(format!(
-                "/tmp directory not found in rootfs at {}. \
-                The rootfs may not be properly bootstrapped.",
-                tmp_dir
-            ))
-            .into());
-        }
-        Err(e) => {
-            return Err(RsdebstrapError::io(
-                format!("failed to read /tmp metadata at {}", tmp_dir),
-                e,
-            )
-            .into());
-        }
-    };
-
-    if metadata.file_type().is_symlink() {
-        return Err(RsdebstrapError::Validation(
-            "/tmp in rootfs is a symlink, which is not allowed for security reasons. \
-            An attacker could use this to write files outside the chroot."
-                .to_string(),
-        )
-        .into());
-    }
-
-    if !metadata.file_type().is_dir() {
-        return Err(RsdebstrapError::Validation(format!(
-            "/tmp in rootfs is not a directory: {}. \
-            The rootfs may not be properly bootstrapped.",
-            tmp_dir
-        ))
-        .into());
-    }
-
-    Ok(())
-}
-
-/// Executes a command within an isolation context, preserving `RsdebstrapError` variants.
-///
-/// If the context returns an `anyhow::Error` that wraps a `RsdebstrapError`, the typed
-/// error is preserved. Otherwise, the error is wrapped with a descriptive context message.
-///
-/// # Arguments
-///
-/// * `context` - The isolation context to execute within
-/// * `command` - The command and arguments to execute
-/// * `task_label` - Human-readable label used in error messages
-/// * `privilege` - Optional privilege escalation method (`sudo`/`doas`) to wrap the command
-pub(crate) fn execute_in_context(
-    context: &dyn IsolationContext,
-    command: &[String],
-    task_label: &str,
-    privilege: Option<PrivilegeMethod>,
-) -> Result<ExecutionResult> {
-    context
-        .execute(command, privilege)
-        .map_err(|e| match e.downcast::<RsdebstrapError>() {
-            Ok(typed) => typed.into(),
-            Err(e) => e.context(format!("failed to execute {}", task_label)),
-        })
-}
-
-/// Checks the execution result and returns an error if the command failed.
-///
-/// Handles three cases:
-/// - Non-zero exit status: returns `Execution` error with the status code
-/// - No exit status in non-dry-run mode: returns `Execution` error (e.g., killed by signal)
-/// - Success or dry-run with no status: returns `Ok(())`
-pub(crate) fn check_execution_result(
-    result: &ExecutionResult,
-    command: &[String],
-    context_name: &str,
-    dry_run: bool,
-) -> Result<()> {
-    match result.status {
-        Some(status) if !status.success() => {
-            Err(
-                RsdebstrapError::execution_in_isolation(command, context_name, status.to_string())
-                    .into(),
-            )
-        }
-        None if !dry_run => Err(RsdebstrapError::execution_in_isolation(
-            command,
-            context_name,
-            "process exited without status (possibly killed by signal)",
-        )
-        .into()),
-        _ => Ok(()),
-    }
-}
-
-/// Re-validates `/tmp` (TOCTOU mitigation) and runs the file preparation closure.
-///
-/// In dry-run mode, skips both validation and file preparation entirely.
-pub(crate) fn prepare_files_with_toctou_check(
-    rootfs: &Utf8Path,
-    dry_run: bool,
-    prepare_fn: impl FnOnce() -> Result<()>,
-) -> Result<()> {
-    if !dry_run {
-        validate_tmp_directory(rootfs)
-            .context("TOCTOU check: /tmp validation failed before writing files")?;
-        prepare_fn()?;
-    }
-    Ok(())
-}
-
 /// Declarative task definition for pipeline steps.
 ///
 /// Each variant holds the data needed to configure and execute a specific
@@ -379,7 +155,7 @@ impl TaskDefinition {
     }
 
     /// Executes the task within the given isolation context.
-    pub fn execute(&self, ctx: &dyn IsolationContext) -> Result<()> {
+    pub fn execute(&self, ctx: &dyn IsolationContext) -> anyhow::Result<()> {
         match self {
             Self::Shell(task) => task.execute(ctx),
             Self::Mitamae(task) => task.execute(ctx),
@@ -442,15 +218,20 @@ impl TaskDefinition {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::fs;
+
+    use camino::Utf8PathBuf;
+
+    use super::file_ops::TempFileGuard;
 
     #[cfg(unix)]
     mod check_execution_result_tests {
         use std::os::unix::process::ExitStatusExt;
         use std::process::ExitStatus;
 
-        use super::*;
+        use crate::error::RsdebstrapError;
         use crate::executor::ExecutionResult;
+        use crate::task::execution::check_execution_result;
 
         #[test]
         fn success_returns_ok() {

--- a/src/task/validation.rs
+++ b/src/task/validation.rs
@@ -1,0 +1,146 @@
+//! Validation utilities for task configuration.
+//!
+//! Provides path traversal checks, file existence validation, and
+//! rootfs /tmp directory verification.
+
+use std::fs;
+
+use anyhow::Result;
+use camino::Utf8Path;
+
+use crate::error::RsdebstrapError;
+
+/// Validates that a path contains no `..` components.
+///
+/// Returns `RsdebstrapError::Validation` if any parent directory component is found.
+/// The `label` parameter is used in error messages to describe the path's purpose
+/// (e.g., "shell script", "mitamae binary").
+pub(crate) fn validate_no_parent_dirs(path: &Utf8Path, label: &str) -> Result<(), RsdebstrapError> {
+    if path
+        .components()
+        .any(|c| c == camino::Utf8Component::ParentDir)
+    {
+        return Err(RsdebstrapError::Validation(format!(
+            "{} path '{}' contains '..' components, \
+            which is not allowed for security reasons",
+            label, path
+        )));
+    }
+    Ok(())
+}
+
+/// Validates that a host-side file exists and is a regular file (not a symlink).
+///
+/// Uses `symlink_metadata` to avoid following symlinks. Returns
+/// `RsdebstrapError::Io` if the file cannot be accessed, or
+/// `RsdebstrapError::Validation` if the path is a symlink or not a regular file.
+/// The `label` parameter is used in error messages (e.g., "shell script", "mitamae binary").
+pub(crate) fn validate_host_file_exists(
+    path: &Utf8Path,
+    label: &str,
+) -> Result<(), RsdebstrapError> {
+    let metadata = fs::symlink_metadata(path).map_err(|e| {
+        RsdebstrapError::io(format!("failed to read {} metadata: {}", label, path), e)
+    })?;
+    if metadata.is_symlink() {
+        return Err(RsdebstrapError::Validation(format!(
+            "{} path '{}' is a symlink, which is not allowed for security reasons",
+            label, path
+        )));
+    }
+    if !metadata.is_file() {
+        return Err(RsdebstrapError::Validation(format!("{} is not a file: {}", label, path)));
+    }
+    Ok(())
+}
+
+/// Validates that /tmp exists as a real directory (not a symlink).
+///
+/// This is a security-critical check to prevent attackers from using symlinks
+/// to write files outside the rootfs.
+pub(crate) fn validate_tmp_directory(rootfs: &Utf8Path) -> Result<()> {
+    let tmp_dir = rootfs.join("tmp");
+    let metadata = match std::fs::symlink_metadata(&tmp_dir) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(RsdebstrapError::Validation(format!(
+                "/tmp directory not found in rootfs at {}. \
+                The rootfs may not be properly bootstrapped.",
+                tmp_dir
+            ))
+            .into());
+        }
+        Err(e) => {
+            return Err(RsdebstrapError::io(
+                format!("failed to read /tmp metadata at {}", tmp_dir),
+                e,
+            )
+            .into());
+        }
+    };
+
+    if metadata.file_type().is_symlink() {
+        return Err(RsdebstrapError::Validation(
+            "/tmp in rootfs is a symlink, which is not allowed for security reasons. \
+            An attacker could use this to write files outside the rootfs."
+                .to_string(),
+        )
+        .into());
+    }
+
+    if !metadata.file_type().is_dir() {
+        return Err(RsdebstrapError::Validation(format!(
+            "/tmp in rootfs is not a directory: {}. \
+            The rootfs may not be properly bootstrapped.",
+            tmp_dir
+        ))
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Validates that a shell path exists and is a regular file in the rootfs.
+///
+/// Checks for path traversal, existence, and that the shell is a regular file.
+pub(crate) fn validate_shell_in_rootfs(shell: &str, rootfs: &Utf8Path) -> Result<()> {
+    let shell_path = shell.trim_start_matches('/');
+    validate_no_parent_dirs(camino::Utf8Path::new(shell_path), "shell")?;
+
+    let shell_in_rootfs = rootfs.join(shell_path);
+    let metadata = match fs::metadata(&shell_in_rootfs) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(RsdebstrapError::Validation(format!(
+                "shell '{}' does not exist in rootfs at {}",
+                shell, shell_in_rootfs
+            ))
+            .into());
+        }
+        Err(e) => {
+            return Err(RsdebstrapError::io(
+                format!("failed to read shell metadata for '{}' at {}", shell, shell_in_rootfs),
+                e,
+            )
+            .into());
+        }
+    };
+
+    if metadata.is_dir() {
+        return Err(RsdebstrapError::Validation(format!(
+            "shell path '{}' points to a directory, not a file: {}",
+            shell, shell_in_rootfs
+        ))
+        .into());
+    }
+
+    if !metadata.is_file() {
+        return Err(RsdebstrapError::Validation(format!(
+            "shell '{}' is not a regular file in rootfs at {}",
+            shell, shell_in_rootfs
+        ))
+        .into());
+    }
+
+    Ok(())
+}

--- a/tests/privilege_test.rs
+++ b/tests/privilege_test.rs
@@ -249,13 +249,7 @@ fn test_default_privilege_doas_inherited() {
 // MockContext-based privilege propagation tests
 // =============================================================================
 
-/// Helper to set up a valid rootfs with /tmp and /bin/sh
-fn setup_valid_rootfs(temp_dir: &tempfile::TempDir) {
-    let rootfs = temp_dir.path();
-    std::fs::create_dir(rootfs.join("tmp")).expect("failed to create tmp dir");
-    std::fs::create_dir_all(rootfs.join("bin")).expect("failed to create bin dir");
-    std::fs::write(rootfs.join("bin/sh"), "#!/bin/sh\n").expect("failed to write /bin/sh");
-}
+use crate::helpers::setup_rootfs_with_shell;
 
 #[test]
 fn test_shell_task_propagates_sudo_privilege_to_mock_context() {
@@ -263,7 +257,7 @@ fn test_shell_task_propagates_sudo_privilege_to_mock_context() {
     let rootfs = camino::Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("path should be valid UTF-8");
 
-    setup_valid_rootfs(&temp_dir);
+    setup_rootfs_with_shell(&temp_dir);
 
     let mut task = ShellTask::new(ScriptSource::Content("echo hello".to_string()));
     let defaults = PrivilegeDefaults {
@@ -291,7 +285,7 @@ fn test_shell_task_propagates_none_privilege_to_mock_context() {
     let rootfs = camino::Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("path should be valid UTF-8");
 
-    setup_valid_rootfs(&temp_dir);
+    setup_rootfs_with_shell(&temp_dir);
 
     let mut task = ShellTask::new(ScriptSource::Content("echo hello".to_string()));
     // No defaults → privilege resolves to None


### PR DESCRIPTION
## Summary
- Extract `Bootstrap`, `IsolationConfig`, and task utilities into dedicated submodules for clearer code organization
- Introduce `impl_inherit_or_explicit_serde!` macro and shared helpers (`check_not_torn_down`, `execute_and_check`, `validate_shell_in_rootfs`) to eliminate duplicated logic
- Add test ergonomics: `assert_error_contains!` macro, `MockContextBuilder`, and shared rootfs setup helpers

## Test plan
- [x] `cargo check --all-targets --all-features --quiet` passes
- [x] `cargo test --quiet` — all 103 tests pass
- [x] `cargo clippy --all-targets --all-features --quiet` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)