### PR TITLE
fix(ci): pin cosign to legacy bundle format for sign-blob

### DIFF
--- a/tasks/build.task.yml
+++ b/tasks/build.task.yml
@@ -135,5 +135,6 @@ tasks:
       cosign sign-blob {{.ARTIFACT}}
       -y
       --use-signing-config=false
+      --new-bundle-format=false
       --output-certificate {{.ARTIFACT}}.cert
       --output-signature {{.ARTIFACT}}.sig


### PR DESCRIPTION
## Summary

Fixes the Build / release job that failed on push to `main` in the cosign signing step.

## Cause

cosign v3 changed the `sign-blob` default to the new bundle format (`--new-bundle-format=true`), which now requires `--bundle`. This project uses the legacy `--output-certificate` / `--output-signature` (`.cert` / `.sig`) outputs, so the step failed with:

```
Error: must specify --bundle with --new-bundle-format
task: Failed to run task "cosign:release:x86_64-unknown-linux-musl": exit status 1
```

This signing step only runs on push to `main` (`matrix.profile == 'release'`), so it did not surface in PR CI.

## Fix

Add `--new-bundle-format=false` to the cosign command in `tasks/build.task.yml` to keep the legacy `.cert` / `.sig` output format.

These files are published to GitHub Releases as `dist/*` via `wc-release.yml`, so switching to the `--bundle` format would change the published artifact layout and affect anyone verifying existing releases. This keeps behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)